### PR TITLE
Bugfix - generation of non-specific padlocks

### DIFF
--- a/lib/readblast.py
+++ b/lib/readblast.py
@@ -69,7 +69,7 @@ def readblastout(file, armlength, variants):
                                     else:
                                         with open(os.path.join(os.path.dirname(file), 'homology.txt'), 'a') as fsimilar:
                                                 fsimilar.write('%s,%s\n' % (hit, variants))
-                                        specific = False
+                                    specific = False
                                 # Otherwise, the hit is specific
                                 else:
                                     # And if it's a perfect match mark it as mappable


### PR DESCRIPTION
There is an edge case in the padlock specificity logic which results in non-specific padlocks not being filtered out correctly.

In the unfixed code it is possible for BLAST hits to be equal to the length of the whole padlock arm region, being an otherwise good match to another gene but not have 100% homology, and thus not be included in the following criterion: 
2 * armlength * 0.5 < int(scores[1]) < 2 * armlength
followed by:
if float(scores[0]) == 100 and int(scores[1]) == 2 * armlength

Another scenario that is not addressed by the current code is when a BLAST hit exceeds 2 * armlength which is possible with a single gap. The BLAST hit may otherwise be a likely candidate for non-specific binding but would currently be accepted as specific.

